### PR TITLE
Use favoredType instead of default if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,19 +20,22 @@ import { detectExtension, detectMimeType } from 'emailjs-mime-types'
 
  Returns file extension for a content type string. If no suitable extensions are found, 'bin' is used as the default extension.
 
-    mimetypes.detectExtension(mimeType -> String) -> String
+    mimetypes.detectExtension(mimeType: String, [favoredExtension: String]) -> String
 
   * **mimeType** - Content type to be checked for
+  * **favoredExtension** (optional) - If multiple extensions exist for type, then pick favoredExtension if available
 
 For example:
 
     mimetypes.detectExtension('image/jpeg') // returns 'jpeg'
+    mimetypes.detectExtension('image/jpeg', 'jpg') // returns 'jpg'
+    mimetypes.detectExtension('image/jpeg', 'txt') // returns 'jpeg'
 
 ### #detectMimeType
 
 Returns content type for a file extension. If no suitable content types are found, 'application/octet-stream' is used as the default content type
 
-    mimetypes.detectMimeType(extension -> String) -> String
+    mimetypes.detectMimeType(extension: String) -> String
 
   * **extension** Extension to be checked for
 

--- a/src/mimetypes-unit.js
+++ b/src/mimetypes-unit.js
@@ -15,6 +15,13 @@ describe('mimetypes', function () {
 
       expect(detectExtension(contentType)).to.equal(extension)
     })
+
+    it('should use favored extension if match', function () {
+      const contentType = 'text/plain'
+      const favoredExtension = 'log'
+
+      expect(detectExtension(contentType, favoredExtension)).to.equal(favoredExtension)
+    })
   })
 
   describe('#detectExtension', function () {

--- a/src/mimetypes.js
+++ b/src/mimetypes.js
@@ -8,7 +8,7 @@ import { types } from './list-types'
  * @param {String} mimeType Content type to be checked for
  * @return {String} File extension
  */
-export function detectExtension (mimeType = '') {
+export function detectExtension (mimeType = '', favoredExtension = '') {
   mimeType = mimeType.toString().toLowerCase().replace(/\s/g, '')
   if (!(mimeType in types)) {
     return 'bin'
@@ -16,6 +16,11 @@ export function detectExtension (mimeType = '') {
 
   if (typeof types[mimeType] === 'string') {
     return types[mimeType]
+  }
+
+  favoredExtension = favoredExtension.toString().toLowerCase().replace(/\s/g, '')
+  if (favoredExtension && types[mimeType].includes(favoredExtension)) {
+    return favoredExtension
   }
 
   // search for name match


### PR DESCRIPTION
Used, for example, when you have a text/plain type, but would rather use the .log extension than the default (the first extension in the array)